### PR TITLE
Added portuguese locale

### DIFF
--- a/locale/pt/better-train-system.cfg
+++ b/locale/pt/better-train-system.cfg
@@ -1,0 +1,40 @@
+[item-name]
+  cargo-wagon-mk2=Vagão de Carga Mk2
+  cargo-wagon-mk3=Vagão de Carga Mk3
+  cargo-wagon-mk4=Vagão de Carga Mk4
+
+  fluid-wagon-mk2=Vagão de Líquidos Mk2
+  fluid-wagon-mk3=Vagão de Líquidos Mk3
+  fluid-wagon-mk4=Vagão de Líquidos Mk4
+
+  locomotive-mk2=Locomotiva Mk2
+  locomotive-mk3=Locomotiva Mk3
+  locomotive-mk4=Locomotiva Mk4
+
+[entity-name]
+  cargo-wagon-mk2=Vagão de Carga Mk2
+  cargo-wagon-mk3=Vagão de Carga Mk3
+  cargo-wagon-mk4=Vagão de Carga Mk4
+
+  fluid-wagon-mk2=Vagão de Líquidos Mk2
+  fluid-wagon-mk3=Vagão de Líquidos Mk3
+  fluid-wagon-mk4=Vagão de Líquidos Mk4
+
+  locomotive-mk2=Locomotiva Mk2
+  locomotive-mk3=Locomotiva Mk3
+  locomotive-mk4=Locomotiva Mk4
+
+[technology-name]
+  railway-2=Ferrovia 2
+  railway-3=Ferrovia 3
+  railway-4=Ferrovia 4
+
+[mod-setting-name]
+  bts-max_speed=Velocidade máxima
+  bts-max_items=Capacidade máxima de carga
+  bts-max_fluid=Capacidade máxima de líquidos
+
+[mod-setting-description]
+  bts-max_speed=em KM/H, tem que estar entre 1 e 7385. Predefinição é 562.
+  bts-max_items=Número máximo de slots para vagões de carga
+  bts-max_fluid=Capacidade máxima de fluídos para vagões de fluídos


### PR DESCRIPTION
Added a Portuguese locale. There are two Portuguese versions, Portugal and Brazil respectively, but this should suffice for the two do not differ enough to justify adding both. I can also use pt_PT to indicate the difference if needed.